### PR TITLE
fix(mobile): Prevent auto-zoom on input focus on iOS (#21)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import 'katex/dist/katex.min.css';
@@ -19,6 +19,10 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'Chat0',
   description: 'Fastest AI Chat App',
+};
+
+export const viewport: Viewport = {
+  maximumScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Fixes #21, where the viewport on iOS Safari would remain zoomed in after a user sends a message, requiring them to manually zoom out.

The fix implements `maximum-scale=1` in the `viewport` export in `app/layout.tsx`. This prevents the browser from scaling the viewport when the chat input is focused, ensuring a consistent and user-friendly experience on mobile devices.

This approach was adopted after several other methods, including css changes, failed to produce the desired behavior.

Result:
![30262](https://github.com/user-attachments/assets/2743ece9-066b-4188-9edd-7a7d2f1b75ad)

Change tested to not affect user experience on other devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved viewport settings to enhance display scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->