### PR TITLE
Google API Key & API Call Optional

### DIFF
--- a/frontend/components/APIKeyForm.tsx
+++ b/frontend/components/APIKeyForm.tsx
@@ -18,9 +18,7 @@ import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { Badge } from './ui/badge';
 
 const formSchema = z.object({
-  google: z.string().trim().min(1, {
-    message: 'Google API key is required for Title Generation',
-  }),
+  google: z.string().trim().optional(),
   openrouter: z.string().trim().optional(),
   openai: z.string().trim().optional(),
 });
@@ -81,7 +79,6 @@ const Form = () => {
         placeholder="AIza..."
         register={register}
         error={errors.google}
-        required
       />
 
       <ApiKeyField

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { StopIcon } from './ui/icons';
 import { toast } from 'sonner';
 import { useMessageSummary } from '../hooks/useMessageSummary';
+import { MODEL_PROVIDERS } from '@/lib/constants';
 
 interface ChatInputProps {
   threadId: string;
@@ -67,6 +68,7 @@ function PureChatInput({
 
   const navigate = useNavigate();
   const { id } = useParams();
+  const { selectedModel } = useModelStore();
 
   const isDisabled = useMemo(
     () => !input.trim() || status === 'streaming' || status === 'submitted',
@@ -87,14 +89,16 @@ function PureChatInput({
 
     const messageId = uuidv4();
 
-    if (!id) {
-      navigate(`/chat/${threadId}`);
-      await createThread(threadId);
-      complete(currentInput.trim(), {
-        body: { threadId, messageId, isTitle: true },
-      });
-    } else {
-      complete(currentInput.trim(), { body: { messageId, threadId } });
+    if (getModelConfig(selectedModel).provider === MODEL_PROVIDERS.GOOGLE) {
+      if (!id) {
+        navigate(`/chat/${threadId}`);
+        await createThread(threadId);
+        complete(currentInput.trim(), {
+          body: { threadId, messageId, isTitle: true },
+        });
+      } else {
+        complete(currentInput.trim(), { body: { messageId, threadId } });
+      }
     }
 
     const userMessage = createUserMessage(messageId, currentInput.trim());

--- a/frontend/components/ChatInput.tsx
+++ b/frontend/components/ChatInput.tsx
@@ -117,6 +117,7 @@ function PureChatInput({
     textareaRef,
     threadId,
     complete,
+    selectedModel,
   ]);
 
   if (!canChat) {

--- a/frontend/hooks/useMessageSummary.ts
+++ b/frontend/hooks/useMessageSummary.ts
@@ -2,6 +2,7 @@ import { useCompletion } from '@ai-sdk/react';
 import { useAPIKeyStore } from '@/frontend/stores/APIKeyStore';
 import { toast } from 'sonner';
 import { createMessageSummary, updateThread } from '@/frontend/dexie/queries';
+import { MODEL_PROVIDERS } from '@/lib/constants';
 
 interface MessageSummaryPayload {
   title: string;
@@ -15,8 +16,8 @@ export const useMessageSummary = () => {
 
   const { complete, isLoading } = useCompletion({
     api: '/api/completion',
-    ...(getKey('google') && {
-      headers: { 'X-Google-API-Key': getKey('google')! },
+    ...(getKey(MODEL_PROVIDERS.GOOGLE) && {
+      headers: { 'X-Google-API-Key': getKey(MODEL_PROVIDERS.GOOGLE)! },
     }),
     onResponse: async (response) => {
       try {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,9 +1,19 @@
-import { Provider } from "@/frontend/stores/APIKeyStore";
+import { Provider } from '@/frontend/stores/APIKeyStore';
+
+const GOOGLE = 'google';
+const OPEN_ROUTER = 'openrouter';
+const OPEN_AI = 'openai';
 
 export const MODEL_PROVIDERS: {
   [key: string]: Provider;
 } = {
-  GOOGLE: "google",
-  OPEN_ROUTER: "openrouter",
-  OPEN_AI: "openai",
+  GOOGLE,
+  OPEN_ROUTER,
+  OPEN_AI,
+} as const;
+
+export const MODEL_HEADER_KEYS: Record<Provider, string> = {
+  [OPEN_ROUTER]: 'X-OpenRouter-API-Key',
+  [GOOGLE]: 'X-Google-API-Key',
+  [OPEN_AI]: 'X-OpenAI-API-Key',
 } as const;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,9 @@
+import { Provider } from "@/frontend/stores/APIKeyStore";
+
+export const MODEL_PROVIDERS: {
+  [key: string]: Provider;
+} = {
+  GOOGLE: "google",
+  OPEN_ROUTER: "openrouter",
+  OPEN_AI: "openai",
+} as const;

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,4 +1,5 @@
 import { Provider } from '@/frontend/stores/APIKeyStore';
+import { MODEL_PROVIDERS } from './constants';
 
 export const AI_MODELS = [
   'Deepseek R1 0528',
@@ -20,32 +21,32 @@ export type ModelConfig = {
 export const MODEL_CONFIGS = {
   'Deepseek R1 0528': {
     modelId: 'deepseek/deepseek-r1-0528:free',
-    provider: 'openrouter',
+    provider: MODEL_PROVIDERS.OPEN_ROUTER,
     headerKey: 'X-OpenRouter-API-Key',
   },
   'Deepseek V3': {
     modelId: 'deepseek/deepseek-chat-v3-0324:free',
-    provider: 'openrouter',
+    provider: MODEL_PROVIDERS.OPEN_ROUTER,
     headerKey: 'X-OpenRouter-API-Key',
   },
   'Gemini 2.5 Pro': {
     modelId: 'gemini-2.5-pro-preview-05-06',
-    provider: 'google',
+    provider: MODEL_PROVIDERS.GOOGLE,
     headerKey: 'X-Google-API-Key',
   },
   'Gemini 2.5 Flash': {
     modelId: 'gemini-2.5-flash-preview-04-17',
-    provider: 'google',
+    provider: MODEL_PROVIDERS.GOOGLE,
     headerKey: 'X-Google-API-Key',
   },
   'GPT-4o': {
     modelId: 'gpt-4o',
-    provider: 'openai',
+    provider: MODEL_PROVIDERS.OPEN_AI,
     headerKey: 'X-OpenAI-API-Key',
   },
   'GPT-4.1-mini': {
     modelId: 'gpt-4.1-mini',
-    provider: 'openai',
+    provider: MODEL_PROVIDERS.OPEN_AI,
     headerKey: 'X-OpenAI-API-Key',
   },
 } as const satisfies Record<AIModel, ModelConfig>;

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@/frontend/stores/APIKeyStore';
-import { MODEL_PROVIDERS } from './constants';
+import { MODEL_HEADER_KEYS, MODEL_PROVIDERS } from '@/lib/constants';
 
 export const AI_MODELS = [
   'Deepseek R1 0528',
@@ -22,32 +22,32 @@ export const MODEL_CONFIGS = {
   'Deepseek R1 0528': {
     modelId: 'deepseek/deepseek-r1-0528:free',
     provider: MODEL_PROVIDERS.OPEN_ROUTER,
-    headerKey: 'X-OpenRouter-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.OPEN_ROUTER],
   },
   'Deepseek V3': {
     modelId: 'deepseek/deepseek-chat-v3-0324:free',
     provider: MODEL_PROVIDERS.OPEN_ROUTER,
-    headerKey: 'X-OpenRouter-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.OPEN_ROUTER],
   },
   'Gemini 2.5 Pro': {
     modelId: 'gemini-2.5-pro-preview-05-06',
     provider: MODEL_PROVIDERS.GOOGLE,
-    headerKey: 'X-Google-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.GOOGLE],
   },
   'Gemini 2.5 Flash': {
     modelId: 'gemini-2.5-flash-preview-04-17',
     provider: MODEL_PROVIDERS.GOOGLE,
-    headerKey: 'X-Google-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.GOOGLE],
   },
   'GPT-4o': {
     modelId: 'gpt-4o',
     provider: MODEL_PROVIDERS.OPEN_AI,
-    headerKey: 'X-OpenAI-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.OPEN_AI],
   },
   'GPT-4.1-mini': {
     modelId: 'gpt-4.1-mini',
     provider: MODEL_PROVIDERS.OPEN_AI,
-    headerKey: 'X-OpenAI-API-Key',
+    headerKey: MODEL_HEADER_KEYS[MODEL_PROVIDERS.OPEN_AI],
   },
 } as const satisfies Record<AIModel, ModelConfig>;
 


### PR DESCRIPTION
- Made Google API key optional.
- Not calling google API when chatting with providers that are not google.
- Added a const which has all providers so that we dont have to hardcode the provider strings in different places


PS: I was not completely sure of the need of Title Generation as I was getting enough information from the normal open AI api's itself, Let me know if it was there for a reason due to which it was written that way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized model provider identifiers, improving consistency across the app.

* **Bug Fixes**
  * Google API key is now optional, and the form no longer marks it as required.

* **Refactor**
  * Updated internal logic to use centralized provider constants instead of hardcoded strings.
  * Adjusted message handling and completion flows to conditionally execute based on the selected model provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->