### PR TITLE
feat(seo): add metadata base url

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://chat0.space"),
   title: {
     default: 'Chat0',
     template: '%s - Chat0',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site metadata to include the official base URL, improving SEO and social sharing previews.
  * Link previews (Open Graph/Twitter) now use absolute URLs with the correct domain across pages.
  * Canonical metadata is more consistent, aiding accurate indexing and sharing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->